### PR TITLE
Collective pageviews for WP L&O 

### DIFF
--- a/R/pageview_analysis.R
+++ b/R/pageview_analysis.R
@@ -35,3 +35,32 @@ ggplot(p, aes(x = date, y = views, group = article, color = article)) +
         axis.text = element_text(size = 13)) + 
   ylab('Daily Pageviews') 
 
+
+# ---- Project Pageviews ---- 
+
+# pages with WP L&O tag 
+pages = WikipediR::page_backlinks(language = 'en', project = 'wikipedia',
+                                  page = 'Wikipedia:WikiProject Limnology and Oceanography',
+                                  limit = 10000)$query$backlinks %>%  bind_rows() %>%
+  dplyr::slice(grep(pattern = 'Talk:', x = title)) %>% 
+  mutate(title = gsub(pattern = 'Talk:', replacement = '', x = title)) %>% 
+  pull(title)
+
+start = '2019010101'
+end = '2019030101'
+
+# mean article views per day within scope of WP L&O over specified date range 
+p = pageviews::article_pageviews(project = 'en.wikipedia', 
+                                 article = pages,
+                                 user_type = 'user', 
+                                 start = start, 
+                                 end = end) %>% 
+  group_by(article) %>% 
+  summarise(views = mean(views)) %>% 
+  arrange(desc(views))
+
+ggplot(p, aes(x = views)) + 
+  geom_histogram() + 
+  scale_x_log10()
+
+


### PR DESCRIPTION
I created a quick analysis of collective pageviews for articles within scope of WP L&O. Since the start of 2019, collectively articles under scope of WP L&O have received over 96,000 pageviews / day. 
![image](https://user-images.githubusercontent.com/4825431/53972453-d1ddf080-40cc-11e9-983e-d6e2d6832f8a.png)
Most articles are between 10 and ~500 pageviews / day. 

Top 10 articles here: 
![image](https://user-images.githubusercontent.com/4825431/53972572-0a7dca00-40cd-11e9-9d95-4d2341d843fc.png)
